### PR TITLE
Apply gofmt on all source files

### DIFF
--- a/hg/hg.go
+++ b/hg/hg.go
@@ -1,13 +1,13 @@
 package hg
 
 import (
-	"os/exec"
-	"fmt"
-	"strings"
-	"os"
 	"encoding/json"
-	"time"
+	"fmt"
+	"os"
+	"os/exec"
 	"path"
+	"strings"
+	"time"
 )
 
 type Repository struct {
@@ -26,13 +26,13 @@ type CommitProperty struct {
 }
 
 type HgChangeset struct {
-	Rev       int `json:"rev"`
-	Node      string `json:"node"`
-	Branch    string `json:"branch"`
-	Phase     string `json:"phase"`
-	User      string `json:"user"`
-	Date      []int64 `json:"date"`
-	Desc      string `json:"desc"`
+	Rev       int      `json:"rev"`
+	Node      string   `json:"node"`
+	Branch    string   `json:"branch"`
+	Phase     string   `json:"phase"`
+	User      string   `json:"user"`
+	Date      []int64  `json:"date"`
+	Desc      string   `json:"desc"`
 	Bookmarks []string `json:"bookmarks"`
 	Tags      []string `json:"tags"`
 	Parents   []string `json:"parents"`
@@ -297,7 +297,7 @@ func parseHgTime(hgTime []int64) (parsedTime time.Time, err error) {
 	utcTime := time.Unix(utcEpoch, 0)
 
 	// for some reason, mercurial uses the inverse sign on the offset
-	zone := time.FixedZone("internet time", -1 * int(offset))
+	zone := time.FixedZone("internet time", -1*int(offset))
 
 	parsedTime = utcTime.In(zone)
 	return
@@ -315,25 +315,25 @@ func (commit *HgChangeset) toCommitProperties() (metadata []CommitProperty, err 
 
 	metadata = append(metadata,
 		CommitProperty{
-			Name: "commit",
+			Name:  "commit",
 			Value: commit.Node,
 		},
 		CommitProperty{
-			Name: "author",
+			Name:  "author",
 			Value: commit.User,
 		},
 		CommitProperty{
-			Name: "author_date",
+			Name:  "author_date",
 			Value: timeToIso8601(timestamp),
-			Type: "time",
+			Type:  "time",
 		},
 		CommitProperty{
-			Name: "message",
+			Name:  "message",
 			Value: commit.Desc,
-			Type: "message",
+			Type:  "message",
 		},
 		CommitProperty{
-			Name: "tags",
+			Name:  "tags",
 			Value: strings.Join(commit.Tags, ", "),
 		},
 	)
@@ -358,7 +358,7 @@ func parseMetadata(hgJsonOutput []byte) (metadata []CommitProperty, err error) {
 }
 
 func (self *Repository) run(command string, args []string) (cmd *exec.Cmd, output []byte, err error) {
-	hgArgs := make([]string, 1, len(args) + 1)
+	hgArgs := make([]string, 1, len(args)+1)
 	hgArgs[0] = command
 
 	if self.SkipSslVerification && commandTakesInsecureOption(command) {
@@ -378,7 +378,7 @@ func commandTakesInsecureOption(command string) bool {
 		"pull",
 		"push",
 	}
-	for _, eligibleCommand := range (eligibleCommands) {
+	for _, eligibleCommand := range eligibleCommands {
 		if command == eligibleCommand {
 			return true
 		}
@@ -404,7 +404,7 @@ func (self *Repository) makeExcludeQueryFragment() string {
 
 func unionOfPaths(paths []string) string {
 	escapedPaths := make([]string, len(paths))
-	for i, path := range (paths) {
+	for i, path := range paths {
 		escapedPaths[i] = "file('re:" + escapePath(path) + "')"
 	}
 	return strings.Join(escapedPaths, "|")

--- a/hg/hg_test.go
+++ b/hg/hg_test.go
@@ -8,7 +8,7 @@ import (
 
 var _ = Describe("Hg", func() {
 	repo := Repository{
-		Path: "/path/to/repo",
+		Path:   "/path/to/repo",
 		Branch: "a_branch",
 		IncludePaths: []string{
 			"/path/1",

--- a/hgresource/check.go
+++ b/hgresource/check.go
@@ -1,26 +1,27 @@
 package main
 
 import (
-	"io"
-	"github.com/concourse/hg-resource/hg"
 	"fmt"
+	"github.com/concourse/hg-resource/hg"
+	"io"
 	"path"
 )
 
 const cmdCheckName string = "check"
+
 var cmdCheck = &Command{
-	Name: cmdCheckName,
-	Run: runCheck,
+	Name:    cmdCheckName,
+	Run:     runCheck,
 	NumArgs: 0,
 }
 
 func runCheck(args []string, params *JsonInput, outWriter io.Writer, errWriter io.Writer) int {
 	repo := hg.Repository{
-		Path: getCacheDir(),
-		Branch: params.Source.Branch,
-		IncludePaths: params.Source.IncludePaths,
-		ExcludePaths: params.Source.ExcludePaths,
-		TagFilter: params.Source.TagFilter,
+		Path:                getCacheDir(),
+		Branch:              params.Source.Branch,
+		IncludePaths:        params.Source.IncludePaths,
+		ExcludePaths:        params.Source.ExcludePaths,
+		TagFilter:           params.Source.TagFilter,
 		SkipSslVerification: params.Source.SkipSslVerification,
 	}
 
@@ -80,7 +81,7 @@ func writeCommitsSince(parentCommit string, repo *hg.Repository, outWriter io.Wr
 	}
 
 	commitList := make([]Version, len(commits))
-	for i, commit := range (commits) {
+	for i, commit := range commits {
 		commitList[i] = Version{
 			Ref: commit,
 		}

--- a/hgresource/in.go
+++ b/hgresource/in.go
@@ -2,27 +2,28 @@ package main
 
 import (
 	"fmt"
-	"io"
 	"github.com/concourse/hg-resource/hg"
+	"io"
 )
 
 const cmdInName string = "in"
+
 var cmdIn = &Command{
-	Name: cmdInName,
-	Run: runIn,
+	Name:    cmdInName,
+	Run:     runIn,
 	NumArgs: 1,
-	Usage: inUsage,
+	Usage:   inUsage,
 }
 
 func runIn(args []string, params *JsonInput, outWriter io.Writer, errWriter io.Writer) int {
 	destination := args[0]
 
 	repo := &hg.Repository{
-		Path: destination,
-		Branch: params.Source.Branch,
-		IncludePaths: params.Source.IncludePaths,
-		ExcludePaths: params.Source.ExcludePaths,
-		TagFilter: params.Source.TagFilter,
+		Path:                destination,
+		Branch:              params.Source.Branch,
+		IncludePaths:        params.Source.IncludePaths,
+		ExcludePaths:        params.Source.ExcludePaths,
+		TagFilter:           params.Source.TagFilter,
 		SkipSslVerification: params.Source.SkipSslVerification,
 	}
 

--- a/hgresource/json_test.go
+++ b/hgresource/json_test.go
@@ -1,10 +1,10 @@
 package main
 
 import (
+	"bytes"
+	"encoding/json"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"encoding/json"
-	"bytes"
 )
 
 var _ = Describe("Json", func() {

--- a/hgresource/main.go
+++ b/hgresource/main.go
@@ -93,7 +93,7 @@ func getHandlerByFirstArgument(args []string) (appName string, handler *Command,
 }
 
 func getHandler(name string) (*Command, error) {
-	for _, cmd := range (commands) {
+	for _, cmd := range commands {
 		if cmd.Name == name {
 			return cmd, nil
 		}
@@ -103,7 +103,7 @@ func getHandler(name string) (*Command, error) {
 
 func makeUsage() string {
 	var commandNames []string
-	for _, cmd := range (commands) {
+	for _, cmd := range commands {
 		commandNames = append(commandNames, cmd.Name)
 	}
 

--- a/hgresource/main_test.go
+++ b/hgresource/main_test.go
@@ -1,10 +1,10 @@
 package main
 
 import (
+	"bytes"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gbytes"
-	"bytes"
 )
 
 var _ = Describe("Main", func() {

--- a/hgresource/out.go
+++ b/hgresource/out.go
@@ -1,22 +1,23 @@
 package main
 
 import (
-	"io"
 	"fmt"
 	"github.com/concourse/hg-resource/hg"
-	"path"
-	"os"
+	"io"
 	"io/ioutil"
-	"time"
+	"os"
+	"path"
 	"strings"
+	"time"
 )
 
 const cmdOutName string = "out"
+
 var cmdOut = &Command{
-	Name: cmdOutName,
-	Run: runOut,
+	Name:    cmdOutName,
+	Run:     runOut,
 	NumArgs: 1,
-	Usage: outUsage,
+	Usage:   outUsage,
 }
 
 type PushParams struct {
@@ -39,8 +40,8 @@ func runOut(args []string, input *JsonInput, outWriter io.Writer, errWriter io.W
 	}
 
 	sourceRepo := &hg.Repository{
-		Path: validatedParams.SourcePath,
-		Branch: validatedParams.Branch,
+		Path:                validatedParams.SourcePath,
+		Branch:              validatedParams.Branch,
 		SkipSslVerification: input.Source.SkipSslVerification,
 	}
 
@@ -84,7 +85,7 @@ func runOut(args []string, input *JsonInput, outWriter io.Writer, errWriter io.W
 func rebaseAndPush(tempRepo *hg.Repository, params PushParams, maxRetries int, errWriter io.Writer) (jsonOutput JsonOutput, err error) {
 	for pushAttempt := 0; pushAttempt < maxRetries; pushAttempt++ {
 		var output []byte
-		fmt.Fprintf(errWriter, "rebasing, attempt %d/%d...\n", pushAttempt + 1, maxRetries)
+		fmt.Fprintf(errWriter, "rebasing, attempt %d/%d...\n", pushAttempt+1, maxRetries)
 		output, err = tempRepo.PullWithRebase(params.DestUri, params.Branch)
 		errWriter.Write(output)
 		if err != nil {
@@ -149,7 +150,7 @@ func getJsonOutputForCurrentCommit(repo *hg.Repository) (output JsonOutput, err 
 
 func isNonFastForwardError(hgStderr string) bool {
 	lines := strings.Split(hgStderr, "\n")
-	for _, line := range (lines) {
+	for _, line := range lines {
 		if strings.HasPrefix(line, "abort: push creates new remote head") {
 			return true
 		}
@@ -163,8 +164,8 @@ func cloneAtCommitIntoTempDir(sourceRepo *hg.Repository, commitId string, errWri
 		return
 	}
 	tempRepo = &hg.Repository{
-		Path: tempRepoDir,
-		Branch: sourceRepo.Branch,
+		Path:                tempRepoDir,
+		Branch:              sourceRepo.Branch,
 		SkipSslVerification: sourceRepo.SkipSslVerification,
 	}
 	cleanupFunc = func(errWriter io.Writer) {
@@ -196,9 +197,9 @@ func validateInput(input *JsonInput, sourceDir string) (validated PushParams, er
 		input.Source.Uri, "uri in resources[repo].source",
 		input.Params.Repository, "repository in <put step>.params",
 	}
-	for i, value := range (requiredParams) {
+	for i, value := range requiredParams {
 		if len(value) == 0 {
-			err = fmt.Errorf("Error: invalid configuration (missing %s)", requiredParams[i + 1])
+			err = fmt.Errorf("Error: invalid configuration (missing %s)", requiredParams[i+1])
 			return
 		}
 	}

--- a/hgresource/ssh.go
+++ b/hgresource/ssh.go
@@ -1,23 +1,23 @@
 package main
 
 import (
-	"os"
-	"path"
-	"fmt"
+	"bytes"
 	"crypto/rand"
 	"encoding/base32"
+	"fmt"
+	"os"
 	"os/exec"
-	"bytes"
-	"strings"
+	"path"
 	"strconv"
+	"strings"
 )
 
 const (
-	tempDirEnv = "TMPDIR"
-	defaultTempDir = "/tmp"
-	keyFileName = "hg-resource-private-key"
-	sshAskpassPath = "/opt/resource/askpass.sh"
-	sshClientConfig = "StrictHostKeyChecking no\nLogLevel quiet\n"
+	tempDirEnv                  = "TMPDIR"
+	defaultTempDir              = "/tmp"
+	keyFileName                 = "hg-resource-private-key"
+	sshAskpassPath              = "/opt/resource/askpass.sh"
+	sshClientConfig             = "StrictHostKeyChecking no\nLogLevel quiet\n"
 	sshClientConfigFileRelative = ".ssh/config"
 )
 
@@ -69,7 +69,7 @@ func addSshKey(keyFilePath string) error {
 	stderr := new(bytes.Buffer)
 	addCmd := exec.Command("ssh-add", keyFilePath)
 	addCmd.Env = append(addCmd.Env, os.Environ()...)
-	addCmd.Env = append(addCmd.Env, "DISPLAY=", "SSH_ASKPASS=" + sshAskpassPath)
+	addCmd.Env = append(addCmd.Env, "DISPLAY=", "SSH_ASKPASS="+sshAskpassPath)
 	addCmd.Stderr = stderr
 	err := addCmd.Run()
 	if err != nil {
@@ -126,7 +126,7 @@ func killSshAgent() error {
 
 func setEnvironmentVariablesFromString(multiLine string) {
 	lines := strings.Split(multiLine, "\n")
-	for _, line := range (lines) {
+	for _, line := range lines {
 		// we don't support any kind of quoting or escaping
 		lineBeforeSemicolon := strings.SplitN(line, ";", 2)
 		keyValue := strings.SplitN(lineBeforeSemicolon[0], "=", 2)

--- a/hgresource/ssh_test.go
+++ b/hgresource/ssh_test.go
@@ -3,9 +3,9 @@ package main
 import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"io/ioutil"
 	"os"
 	"path"
-	"io/ioutil"
 	"strconv"
 	"syscall"
 )
@@ -105,7 +105,6 @@ var _ = Describe("Ssh", func() {
 
 		It("can find the users home directory", func() {
 			homeDir, err := getHomeDir()
-
 
 			Expect(err).To(BeNil())
 			Expect(homeDir).To(Equal("/some/home/directory"))

--- a/hgresource/types.go
+++ b/hgresource/types.go
@@ -1,21 +1,21 @@
 package main
 
 import (
-	"fmt"
-	"encoding/json"
-	"io"
 	"bytes"
+	"encoding/json"
+	"fmt"
 	"github.com/concourse/hg-resource/hg"
+	"io"
 )
 
 type Source struct {
-	Uri string `json:"uri"`
-	PrivateKey string `json:"private_key"`
-	IncludePaths []string `json:"paths"`
-	ExcludePaths []string `json:"ignore_paths"`
-	Branch string `json:"branch"`
-	TagFilter string `json:"tag_filter"`
-	SkipSslVerification bool `json:"skip_ssl_verification"`
+	Uri                 string   `json:"uri"`
+	PrivateKey          string   `json:"private_key"`
+	IncludePaths        []string `json:"paths"`
+	ExcludePaths        []string `json:"ignore_paths"`
+	Branch              string   `json:"branch"`
+	TagFilter           string   `json:"tag_filter"`
+	SkipSslVerification bool     `json:"skip_ssl_verification"`
 }
 
 type Version struct {
@@ -24,20 +24,20 @@ type Version struct {
 
 type Params struct {
 	Repository string `json:"repository"`
-	Tag string `json:"tag"`
-	TagPrefix string `json:"tag_prefix"`
-	Rebase bool `json:"rebase"`
+	Tag        string `json:"tag"`
+	TagPrefix  string `json:"tag_prefix"`
+	Rebase     bool   `json:"rebase"`
 }
 
 type JsonInput struct {
-	Source  Source `json:"source"`
+	Source  Source  `json:"source"`
 	Version Version `json:"version"`
-	Params Params `json:"params"`
+	Params  Params  `json:"params"`
 }
 
 type JsonOutput struct {
 	Metadata []hg.CommitProperty `json:"metadata"`
-	Version Version `json:"version"`
+	Version  Version             `json:"version"`
 }
 
 func parseInput(inReader io.Reader) (*JsonInput, error) {


### PR DESCRIPTION
My editor runs gofmt  automatically, and I guess it is the case for most go developers.

Having the source files not gofmt-ok makes it painful to write clear patches.

I would appreciate this PR to be accepted so writing patches gets easier.