### PR TITLE
Add "revset_filter" repository setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,10 @@ Tracks the commits in a [Mercurial](https://www.mercurial-scm.org/) repository.
 * `tag_filter`: *Optional*. If specified, the resource will only detect commits
   that have a tag matching the specified regular expression.
 
+* `revset_filter`: *Optional*. If specified, the resource will only detect commits
+  that matches the specified revset expression
+  (see https://www.mercurial-scm.org/repo/hg/help/revsets).
+
 ### Example
 
 Resource configuration for a private repo:

--- a/hgresource/check.go
+++ b/hgresource/check.go
@@ -22,6 +22,7 @@ func runCheck(args []string, params *JsonInput, outWriter io.Writer, errWriter i
 		IncludePaths:        params.Source.IncludePaths,
 		ExcludePaths:        params.Source.ExcludePaths,
 		TagFilter:           params.Source.TagFilter,
+		RevSetFilter:        params.Source.RevSetFilter,
 		SkipSslVerification: params.Source.SkipSslVerification,
 	}
 

--- a/hgresource/in.go
+++ b/hgresource/in.go
@@ -24,6 +24,7 @@ func runIn(args []string, params *JsonInput, outWriter io.Writer, errWriter io.W
 		IncludePaths:        params.Source.IncludePaths,
 		ExcludePaths:        params.Source.ExcludePaths,
 		TagFilter:           params.Source.TagFilter,
+		RevSetFilter:        params.Source.RevSetFilter,
 		SkipSslVerification: params.Source.SkipSslVerification,
 	}
 

--- a/hgresource/json_test.go
+++ b/hgresource/json_test.go
@@ -27,6 +27,7 @@ var _ = Describe("Json", func() {
 					],
 					"branch": "a_branch",
 					"tag_filter": "staging",
+					"revset_filter": "public()",
 					"skip_ssl_verification": true
 				},
 				"version": {
@@ -84,6 +85,7 @@ var _ = Describe("Json", func() {
 			Expect(result.Source.Branch).To(Equal("a_branch"))
 			Expect(result.Source.SkipSslVerification).To(BeTrue())
 			Expect(result.Source.TagFilter).To(Equal("staging"))
+			Expect(result.Source.RevSetFilter).To(Equal("public()"))
 			Expect(result.Version.Ref).To(Equal("abc"))
 		})
 	})

--- a/hgresource/types.go
+++ b/hgresource/types.go
@@ -15,6 +15,7 @@ type Source struct {
 	ExcludePaths        []string `json:"ignore_paths"`
 	Branch              string   `json:"branch"`
 	TagFilter           string   `json:"tag_filter"`
+	RevSetFilter        string   `json:"revset_filter"`
 	SkipSslVerification bool     `json:"skip_ssl_verification"`
 }
 

--- a/test/helpers.sh
+++ b/test/helpers.sh
@@ -368,6 +368,32 @@ check_uri_with_tag_filter_from_ref() {
   }" | ${resource_dir}/check | tee /dev/stderr
 }
 
+check_uri_with_revset_filter() {
+  local uri=$1
+  local revset_filter=$2
+  jq -n "{
+    source: {
+      uri: $(echo $uri | jq -R .),
+      revset_filter: $(echo $revset_filter | jq -R .)
+    }
+  }" | ${resource_dir}/check | tee /dev/stderr
+}
+
+check_uri_with_revset_filter_from_ref() {
+  local uri=$1
+  local ref=$2
+  local revset_filter=$3
+  jq -n "{
+    source: {
+      uri: $(echo $uri | jq -R .),
+      revset_filter: $(echo $revset_filter | jq -R .)
+    },
+    version: {
+      ref: $(echo $ref | jq -R .)
+    }
+  }" | ${resource_dir}/check | tee /dev/stderr
+}
+
 get_uri() {
   jq -n "{
     source: {

--- a/test/test_check.sh
+++ b/test/test_check.sh
@@ -254,6 +254,31 @@ test_it_can_check_with_tag_filter_from_a_ref() {
   assertEquals "$expected" "$(check_uri_with_tag_filter_from_ref $repo $ref2 '-staging$' | jq '.')"
 }
 
+test_it_can_check_with_revset_filter() {
+  local repo=$(init_repo)
+  local ref1=$(make_commit $repo)
+  local ref2=$(make_annotated_tag $repo "1.0-staging" "a tag")
+  local ref3=$(make_commit $repo)
+  local ref4=$(make_annotated_tag $repo "1.0-production" "another tag")
+  local ref5=$(make_commit $repo)
+
+  local expected=$(echo "[{\"ref\": $(echo $ref1 | jq -R .)}]" | jq ".")
+  assertEquals "$expected" "$(check_uri_with_revset_filter $repo 'tag("re:-staging$")' | jq '.')"
+}
+
+test_it_can_check_with_revset_filter_from_a_ref() {
+  local repo=$(init_repo)
+  local ref1=$(make_commit $repo)
+  local ref2=$(make_annotated_tag $repo "1.0-staging" "a tag")
+  local ref3=$(make_commit $repo)
+  local ref4=$(make_annotated_tag $repo "1.0-production" "another tag")
+  local ref5=$(make_commit $repo)
+  local ref6=$(make_annotated_tag $repo "1.1-staging" "much tag")
+
+  local expected=$(echo "[{\"ref\": $(echo $ref5 | jq -R .)}]" | jq ".")
+  assertEquals "$expected" "$(check_uri_with_revset_filter_from_ref $repo $ref2 'tag("re:-staging$")' | jq '.')"
+}
+
 test_it_can_check_from_head_only_fetching_single_branch() {
   local repo=$(init_repo)
   local ref=$(make_commit $repo)


### PR DESCRIPTION
A lot of cases are not covered by 'tag_filter' (filtering by bookmark or cset phase for ex).

Instead of adding endless settings to cover them, this patch proposes to give direct access to the revset expression language, through the "revset_filter" option.