### PR TITLE
Enable 'evolve' and 'topic'

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,8 @@
 FROM concourse/buildroot:hg
 
+RUN hg clone https://www.mercurial-scm.org/repo/evolve -r mercurial-3.9 && (cd evolve && python setup.py install) && rm -r evolve
+COPY hgrc /etc/mercurial/hgrc
+
 RUN mkdir -p /opt/resource
 ADD hgresource/hgresource /opt/resource
 ADD assets/askpass.sh /opt/resource

--- a/hgrc
+++ b/hgrc
@@ -1,0 +1,6 @@
+[phases]
+publish = False
+
+[extensions]
+evolve =
+topic =


### PR DESCRIPTION
These two extensions will not temper with repository that are not using them in the first place, but for those that do, it makes a huge difference having them enabled in concourse:

- obsolescence markers are exchanged with upstream, which avoid pruned changeset to trigger any build (this was the biggest issue)
- topic is visible in the metadata, which is pretty useful when looking at a failed build.

I am already successfully using this patch in my pipeline.