### PR TITLE
Enable 'evolve'

### DIFF
--- a/dockerfiles/alpine/Dockerfile
+++ b/dockerfiles/alpine/Dockerfile
@@ -17,7 +17,14 @@ RUN apk add --update \
     jq \
     openssh \
     tar \
-    mercurial
+    python2 \
+    python2-dev \
+    py2-pip \
+    build-base
+
+RUN pip2 install mercurial
+RUN pip2 install hg-evolve
+
 COPY --from=builder /assets /opt/resource
 ADD assets/askpass.sh /opt/resource
 RUN chmod +x /opt/resource/*

--- a/dockerfiles/ubuntu/Dockerfile
+++ b/dockerfiles/ubuntu/Dockerfile
@@ -15,8 +15,16 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
       gnupg \
       jq \
       openssh-client \
-      mercurial \
-    && rm -rf /var/lib/apt/lists/*
+      python \
+      python-pip \
+      build-essential \
+      python-all-dev \
+      python-setuptools \
+      python-wheel \
+    && rm -rf /var/lib/apt/lists/* \
+    && pip2 install mercurial \
+    && pip2 install hg-evolve
+
 COPY --from=builder /assets /opt/resource
 ADD assets/askpass.sh /opt/resource
 RUN chmod +x /opt/resource/*

--- a/hgrc
+++ b/hgrc
@@ -3,3 +3,6 @@ username = User Name <user@example.com>
 
 [phases]
 publish = false
+
+[extensions]
+evolve =


### PR DESCRIPTION
Rebased the evolve work done in #9. Added in a test. Changed to pulling mercurial from pip since evolve is hosted on pip. If that is an issue and we need to revert back to pulling the mercurial package, we will need to wait for alpine linux to release mercurial `5.0.2` due to [this bug in mercurial](https://bz.mercurial-scm.org/show_bug.cgi?id=6149).

I did not rebase the bookmark and topic features, these are not mercurial features I use, and I don't feel comfortable vetting the changes.

During testing I experienced some issues running tests, the race condition tests were very flakey. Unsure if that is due to the evolve introduction or something inherent to the tests.

Thank you @cdevienne for the initial work.