### PR TITLE
Pull does not pass current sourceUri

### DIFF
--- a/hg/hg.go
+++ b/hg/hg.go
@@ -52,7 +52,7 @@ func (self *Repository) CloneOrPull(sourceUri string) ([]byte, error) {
 	if errIfNotExists != nil || !dirInfo.IsDir() {
 		return self.clone(sourceUri)
 	} else {
-		return self.pull()
+		return self.pull(sourceUri)
 	}
 }
 
@@ -70,10 +70,11 @@ func (self *Repository) clone(sourceUri string) (output []byte, err error) {
 	return
 }
 
-func (self *Repository) pull() (output []byte, err error) {
+func (self *Repository) pull(sourceUri string) (output []byte, err error) {
 	_, output, err = self.run("pull", []string{
 		"-q",
 		"--cwd", self.Path,
+		sourceUri,
 	})
 	if err != nil {
 		err = fmt.Errorf("Error pulling changes from repository: %s", err)

--- a/test/test_in.sh
+++ b/test/test_in.sh
@@ -162,4 +162,20 @@ test_it_can_get_with_ssl_cert_checks_disabled() {
   sleep 0.1
 }
 
+test_path_changed() {
+  local repo1=$(init_repo)
+  local repo1_ref=$(make_commit $repo1)
+  local repo2=$(mktemp -d $TMPDIR/repo.XXXXXX)
+  cp -r -T $repo1 $repo2
+  local repo2_ref=$(make_commit $repo2)
+
+  local dest=$TMPDIR/destination
+
+  local expected1=$(echo "{\"ref\": $(echo $repo1_ref | jq -R .)}" | jq ".")
+  assertEquals "$expected1" "$(get_uri_at_ref $repo1 $repo1_ref $dest | jq '.version')"
+
+  local expected2=$(echo "{\"ref\": $(echo $repo2_ref | jq -R .)}" | jq ".")
+  assertEquals "$expected2" "$(get_uri_at_ref $repo2 $repo2_ref $dest | jq '.version')"
+}
+
 source $(dirname $0)/shunit2


### PR DESCRIPTION
The routine `hg.pull` was not being passed the current sourceUri, which could
cause issues in a couple situations. For me, it was manifesting as mercurial
not saving the full uri in the `hgrc` file, it was omitting the basic auth
password. It could also conceivably use an old path if the repo is not purged
whenever the uri param is changed, unsure if concourse would allow that case to
happen.