### PR TITLE
Fix for #17

### DIFF
--- a/dockerfiles/ubuntu/Dockerfile
+++ b/dockerfiles/ubuntu/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_image
+ARG base_image=ubuntu:latest
 ARG builder_image=concourse/golang-builder
 
 FROM ${builder_image} as builder

--- a/hgresource/ssh.go
+++ b/hgresource/ssh.go
@@ -51,11 +51,31 @@ func loadSshPrivateKey(privateKeyPem string) error {
 
 	sshClientConfigFile := path.Join(homeDir, sshClientConfigFileRelative)
 
+	err = mkSSHDir(sshClientConfigFile)
+	if err != nil {
+		return err
+	}
 	err = ioutil.WriteFile(sshClientConfigFile, []byte(sshClientConfig), 0600)
 	if err != nil {
 		return err
 	}
 
+	return nil
+}
+
+func mkSSHDir(sshClientConfigFile string) error {
+	sshDir := path.Dir(sshClientConfigFile)
+	_, pathErr := os.Stat(sshDir)
+	if pathErr != nil {
+		err := os.MkdirAll(sshDir, 0700)
+		if err != nil {
+			return fmt.Errorf("could not create .ssh dir: %s", err)
+		}
+		err = os.Chmod(sshDir, 0700)
+		if err != nil {
+			return fmt.Errorf("failed setting rights: %s", err)
+		}
+	}
 	return nil
 }
 

--- a/hgresource/ssh_test.go
+++ b/hgresource/ssh_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"os"
+	"path"
 	"strconv"
 	"syscall"
 
@@ -49,5 +50,43 @@ var _ = Describe("Ssh", func() {
 				return processExists(pid)
 			}).Should(BeFalse())
 		})
+	})
+
+	homeDir := "/tmp"
+	sshDir := path.Join(homeDir, ".ssh")
+	sshClientConfigFile := path.Join(homeDir, ".ssh/config")
+
+	Context("When configuring ssh", func() {
+		It("can crete the directory", func() {
+
+			// ensure the directory doesn't exists
+			_, sshDirErr := os.Stat(sshDir)
+			Expect(sshDirErr).NotTo(BeNil())
+
+			err := mkSSHDir(sshClientConfigFile)
+			Expect(err).To(BeNil())
+
+			// check that the directory now exists
+			_, resultErr := os.Stat(sshDir)
+			Expect(resultErr).To(BeNil())
+
+			// cleanup
+			err = os.RemoveAll(sshDir)
+			Expect(err).To(BeNil())
+		})
+		It("can ignores when the directory already exists", func() {
+
+			// make sure the directory already exists
+			sshDirErr := os.MkdirAll(sshDir, 0700)
+			Expect(sshDirErr).To(BeNil())
+
+			err := mkSSHDir(sshClientConfigFile)
+			Expect(err).To(BeNil())
+
+			// cleanup
+			err = os.RemoveAll(sshDir)
+			Expect(err).To(BeNil())
+		})
+
 	})
 })

--- a/hgresource/ssh_test.go
+++ b/hgresource/ssh_test.go
@@ -52,11 +52,16 @@ var _ = Describe("Ssh", func() {
 		})
 	})
 
-	homeDir := "/tmp"
-	sshDir := path.Join(homeDir, ".ssh")
-	sshClientConfigFile := path.Join(homeDir, ".ssh/config")
-
 	Context("When configuring ssh", func() {
+		homeDir := "/tmp"
+		sshDir := path.Join(homeDir, ".ssh")
+		sshClientConfigFile := path.Join(homeDir, ".ssh/config")
+
+		AfterEach(func() {
+			// cleanup
+			err := os.RemoveAll(sshDir)
+			Expect(err).To(BeNil())
+		})
 		It("can crete the directory", func() {
 
 			// ensure the directory doesn't exists
@@ -69,10 +74,6 @@ var _ = Describe("Ssh", func() {
 			// check that the directory now exists
 			_, resultErr := os.Stat(sshDir)
 			Expect(resultErr).To(BeNil())
-
-			// cleanup
-			err = os.RemoveAll(sshDir)
-			Expect(err).To(BeNil())
 		})
 		It("can ignores when the directory already exists", func() {
 
@@ -81,10 +82,6 @@ var _ = Describe("Ssh", func() {
 			Expect(sshDirErr).To(BeNil())
 
 			err := mkSSHDir(sshClientConfigFile)
-			Expect(err).To(BeNil())
-
-			// cleanup
-			err = os.RemoveAll(sshDir)
 			Expect(err).To(BeNil())
 		})
 


### PR DESCRIPTION
Fixed ubuntu docker file and ssh dir issue

Created a function, based on the old atomicSave, that creates the `.ssh`
dir.

This should close #17, I'm not that fluent in golang, and I don't really know how I would setup ssh to be able to test. But we built an image and our pipeline works with it.