### PR TITLE
Add --target when running tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,8 +138,8 @@ will stop the build.
 Run the tests with the following commands for both `alpine` and `ubuntu` images:
 
 ```sh
-docker build -t hg-resource -f dockerfiles/alpine/Dockerfile .
-docker build -t hg-resource -f dockerfiles/ubuntu/Dockerfile .
+docker build -t hg-resource --target tests -f dockerfiles/alpine/Dockerfile .
+docker build -t hg-resource --target tests -f dockerfiles/ubuntu/Dockerfile .
 ```
 
 ### Contributing


### PR DESCRIPTION
Docker doesn't blindly build all targets anymore. To run the tests you
need to specify the --target